### PR TITLE
Fix delete dialog not dismissing

### DIFF
--- a/lib/features/todos/screens/todo.dart
+++ b/lib/features/todos/screens/todo.dart
@@ -83,9 +83,8 @@ class _ConfirmDeleteDialog extends HookConsumerWidget {
         await ref.read(todosProvider.notifier).delete(id);
 
         if (!context.mounted) return;
-        context
-          ..pop()
-          ..go('/todos');
+        Navigator.pop(context);
+        context.go('/todos');
       } on DioException catch (e) {
         if (!context.mounted) return;
 
@@ -108,7 +107,7 @@ class _ConfirmDeleteDialog extends HookConsumerWidget {
           : null,
       actions: [
         TextButton(
-          onPressed: () => context.pop(),
+          onPressed: () => Navigator.pop(context),
           child: const Text('No'),
         ),
         TextButton(


### PR DESCRIPTION
Fixes https://github.com/dhafinrayhan/dummymart/issues/5.

`context.pop()` is basically `GoRouter.of(context).pop()`, while what we need to dismiss the dialog is `Navigator.of(context).pop()`, which is what `Navigator.pop(context)` does.